### PR TITLE
fix(folha-ponto): remove outer join from pessimistic lock query

### DIFF
--- a/src/modules/estagio/folha-ponto/application/commands/folha-ponto-token-confirm.handler.ts
+++ b/src/modules/estagio/folha-ponto/application/commands/folha-ponto-token-confirm.handler.ts
@@ -30,10 +30,11 @@ export class FolhaPontoTokenConfirmHandler {
     userAgent: string | null,
   ): Promise<{ acao: FolhaPontoTokenTipo; folhaPontoId: string; folhaPonto: FolhaPonto }> {
     return this.dataSource.transaction(async (manager) => {
-      // 1. Pessimistic Lock no token para evitar duplo-clique
+      // 1. Pessimistic Lock no token para evitar duplo-clique.
+      // IMPORTANTE: não carregar relations junto com o lock — o PostgreSQL não aceita
+      // FOR UPDATE em outer joins ("cannot be applied to the nullable side of an outer join").
       const tokenEntity = await manager.getRepository(FolhaPontoTokenTypeormEntity).findOne({
         where: { id: tokenId },
-        relations: { folhaPonto: true },
         lock: { mode: "pessimistic_write" },
       });
       if (!tokenEntity) {

--- a/src/modules/estagio/folha-ponto/infrastructure.database/typeorm/folha-ponto-token.typeorm.entity.ts
+++ b/src/modules/estagio/folha-ponto/infrastructure.database/typeorm/folha-ponto-token.typeorm.entity.ts
@@ -10,6 +10,11 @@ export class FolhaPontoTokenTypeormEntity {
   @JoinColumn({ name: "id_folha_ponto_fk" })
   folhaPonto!: Relation<FolhaPontoTypeormEntity>;
 
+  // Coluna FK acessível diretamente — usada quando a relation não é carregada
+  // (ex: queries com pessimistic lock que não permitem outer join + FOR UPDATE)
+  @Column({ name: "id_folha_ponto_fk", nullable: true })
+  folhaPontoId!: string;
+
   @Column({ name: "tipo", type: "varchar", length: 20 })
   tipo!: string;
 

--- a/src/modules/estagio/folha-ponto/infrastructure.database/typeorm/folha-ponto-token.typeorm.mapper.ts
+++ b/src/modules/estagio/folha-ponto/infrastructure.database/typeorm/folha-ponto-token.typeorm.mapper.ts
@@ -19,7 +19,7 @@ export const FolhaPontoTokenTypeormMapper = {
   entityToDomain: createMapper<FolhaPontoTokenTypeormEntity, FolhaPontoToken>((entity) => {
     return FolhaPontoToken.load({
       id: entity.id,
-      folhaPonto: { id: entity.folhaPonto?.id || entity["id_folha_ponto_fk"] },
+      folhaPonto: { id: entity.folhaPonto?.id ?? entity.folhaPontoId },
       tipo: entity.tipo as any,
       expiresAt: entity.expiresAt,
       usedAt: entity.usedAt,


### PR DESCRIPTION
PostgreSQL rejeita FOR UPDATE em outer joins ('FOR UPDATE cannot be applied to the nullable side of an outer join').
- Remove relations do findOne com lock pessimistic_write
- Mapeia folhaPontoId diretamente da coluna id_folha_ponto_fk sem JOIN