### PR TITLE
feat(folha-ponto): require explicit button confirmation on GET to pre…

### DIFF
--- a/src/modules/estagio/folha-ponto/presentation.rest/folha-ponto-token.rest.controller.spec.ts
+++ b/src/modules/estagio/folha-ponto/presentation.rest/folha-ponto-token.rest.controller.spec.ts
@@ -11,78 +11,59 @@ describe("FolhaPontoTokenRestController", () => {
     quantidadeHoras: 1,
   };
 
-  it("deve renderizar página HTML de aprovação com sucesso", async () => {
+  const mockToken = {
+    id: "test-token-uuid-1234",
+    tipo: FolhaPontoTokenTipo.APROVACAO,
+    folhaPonto: { id: mockFolhaPonto.id },
+  };
+
+  const createMockResponse = () => {
+    const headers: Record<string, string> = {};
+    return {
+      setHeader: vi.fn((key: string, value: string) => {
+        headers[key] = value;
+      }),
+      headers,
+    };
+  };
+
+  it("GET: deve renderizar tela de confirmação com botão de ação (sem consumir token)", async () => {
     const mockHandler = {
-      confirmar: vi.fn().mockResolvedValue({
-        acao: FolhaPontoTokenTipo.APROVACAO,
-        folhaPontoId: mockFolhaPonto.id,
+      validar: vi.fn().mockResolvedValue({
+        token: mockToken,
         folhaPonto: mockFolhaPonto,
       }),
     };
 
     const controller = new FolhaPontoTokenRestController(mockHandler as any, {} as any);
-    const mockReq = { ip: "127.0.0.1", headers: { "user-agent": "Mozilla/5.0" } };
 
-    const html = await controller.confirmarViaLink("test-uuid-aprovacao", mockReq as any);
+    const html = await controller.exibirConfirmacao("test-uuid-aprovacao");
 
-    expect(html).toContain("Folha de Ponto Aprovada");
+    expect(html).toContain("Aprovar Folha de Ponto");
     expect(html).toContain("2026-08-24");
     expect(html).toContain("15:30 até 16:30");
     expect(html).toContain("1h");
-    expect(html).toContain("A folha de ponto foi aprovada com sucesso");
+    expect(html).toContain("Confirmar Aprovação");
+    expect(html).toContain('<form method="POST"');
+    expect(mockHandler.validar).toHaveBeenCalledWith("test-uuid-aprovacao");
   });
 
-  it("deve renderizar página HTML de rejeição com sucesso", async () => {
+  it("GET: deve renderizar tela de erro quando o token é inválido ou expirado", async () => {
     const mockHandler = {
-      confirmar: vi.fn().mockResolvedValue({
-        acao: FolhaPontoTokenTipo.REJEICAO,
-        folhaPontoId: mockFolhaPonto.id,
-        folhaPonto: mockFolhaPonto,
-      }),
+      validar: vi
+        .fn()
+        .mockRejectedValue(new Error("Este link expirou e não pode mais ser utilizado.")),
     };
 
     const controller = new FolhaPontoTokenRestController(mockHandler as any, {} as any);
-    const mockReq = { ip: "127.0.0.1", headers: { "user-agent": "Mozilla/5.0" } };
 
-    const html = await controller.confirmarViaLink("test-uuid-rejeicao", mockReq as any);
-
-    expect(html).toContain("Folha de Ponto Rejeitada");
-    expect(html).toContain("A folha de ponto foi rejeitada");
-  });
-
-  it("deve renderizar página HTML de cancelamento com sucesso", async () => {
-    const mockHandler = {
-      confirmar: vi.fn().mockResolvedValue({
-        acao: FolhaPontoTokenTipo.CANCELAMENTO,
-        folhaPontoId: mockFolhaPonto.id,
-        folhaPonto: mockFolhaPonto,
-      }),
-    };
-
-    const controller = new FolhaPontoTokenRestController(mockHandler as any, {} as any);
-    const mockReq = { ip: "127.0.0.1", headers: { "user-agent": "Mozilla/5.0" } };
-
-    const html = await controller.confirmarViaLink("test-uuid-cancelamento", mockReq as any);
-
-    expect(html).toContain("Folha de Ponto Cancelada");
-    expect(html).toContain("A solicitação da folha de ponto foi cancelada");
-  });
-
-  it("deve renderizar página de erro amigável quando o token é inválido ou expirado", async () => {
-    const mockHandler = {
-      confirmar: vi.fn().mockRejectedValue(new Error("Este link já foi utilizado anteriormente.")),
-    };
-
-    const controller = new FolhaPontoTokenRestController(mockHandler as any, {} as any);
-    const mockReq = { ip: "127.0.0.1", headers: { "user-agent": "Mozilla/5.0" } };
-
-    const html = await controller.confirmarViaLink("test-uuid-invalido", mockReq as any);
+    const html = await controller.exibirConfirmacao("test-uuid-expirado");
 
     expect(html).toContain("Link Inválido ou Expirado");
-    expect(html).toContain("Este link já foi utilizado anteriormente.");
+    expect(html).toContain("Este link expirou e não pode mais ser utilizado.");
   });
 
-  it("deve confirmar ação via endpoint POST e retornar JSON", async () => {
+  it("POST (browser/HTML): deve confirmar a ação e retornar a página de sucesso", async () => {
     const mockHandler = {
       confirmar: vi.fn().mockResolvedValue({
         acao: FolhaPontoTokenTipo.APROVACAO,
@@ -92,9 +73,37 @@ describe("FolhaPontoTokenRestController", () => {
     };
 
     const controller = new FolhaPontoTokenRestController(mockHandler as any, {} as any);
-    const mockReq = { ip: "127.0.0.1", headers: { "user-agent": "PostmanRuntime" } };
+    const mockReq = { ip: "127.0.0.1", headers: { "user-agent": "Mozilla/5.0" } };
+    const mockRes = createMockResponse();
 
-    const result = await controller.confirmar("test-uuid-post", mockReq as any);
+    const html = await controller.confirmar("test-uuid-post", mockReq as any, mockRes as any);
+
+    expect(html).toContain("Folha de Ponto Aprovada");
+    expect(html).toContain("A folha de ponto foi aprovada com sucesso");
+    expect(mockRes.setHeader).toHaveBeenCalledWith("Content-Type", "text/html; charset=utf-8");
+  });
+
+  it("POST (API/JSON): deve confirmar a ação e retornar JSON", async () => {
+    const mockHandler = {
+      confirmar: vi.fn().mockResolvedValue({
+        acao: FolhaPontoTokenTipo.APROVACAO,
+        folhaPontoId: mockFolhaPonto.id,
+        folhaPonto: mockFolhaPonto,
+      }),
+    };
+
+    const controller = new FolhaPontoTokenRestController(mockHandler as any, {} as any);
+    const mockReq = {
+      ip: "127.0.0.1",
+      headers: { "user-agent": "PostmanRuntime", accept: "application/json" },
+    };
+    const mockRes = createMockResponse();
+
+    const result = await controller.confirmar(
+      "test-uuid-post-json",
+      mockReq as any,
+      mockRes as any,
+    );
 
     expect(result).toEqual({
       sucesso: true,

--- a/src/modules/estagio/folha-ponto/presentation.rest/folha-ponto-token.rest.controller.ts
+++ b/src/modules/estagio/folha-ponto/presentation.rest/folha-ponto-token.rest.controller.ts
@@ -8,11 +8,12 @@ import {
   ParseUUIDPipe,
   Post,
   Req,
+  Res,
   UseGuards,
 } from "@nestjs/common";
 import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { Throttle, ThrottlerGuard } from "@nestjs/throttler";
-import type { Request } from "express";
+import type { Request, Response } from "express";
 import { IConfigService } from "@/infrastructure.config";
 import { Public } from "@/server/nest/auth";
 import { FolhaPontoTokenConfirmHandler } from "../application/commands/folha-ponto-token-confirm.handler";
@@ -33,6 +34,7 @@ type PageConfig = {
   horaFim?: string;
   quantidadeHoras?: number;
   nomeEstagiario?: string;
+  botaoTexto?: string;
 };
 
 function formatarHoras(horas: number): string {
@@ -54,6 +56,13 @@ function renderizarPagina(cfg: PageConfig): string {
           ${cfg.nomeEstagiario ? `<div class="card-row"><span class="label">👤 Estagiário</span><span>${cfg.nomeEstagiario}</span></div>` : ""}
         </div>`
       : "";
+
+  const botaoAcao = cfg.botaoTexto
+    ? `
+      <form method="POST" style="margin-top: 1.5rem;">
+        <button type="submit" class="btn-confirmar">${cfg.botaoTexto}</button>
+      </form>`
+    : `<div class="badge">Ladesa</div>`;
 
   return `<!DOCTYPE html>
 <html lang="pt-BR">
@@ -82,8 +91,8 @@ function renderizarPagina(cfg: PageConfig): string {
       text-align: center;
     }
     .emoji { font-size: 4rem; line-height: 1; margin-bottom: 1rem; }
-    h1 { font-size: 1.6rem; font-weight: 700; color: ${cfg.corPrimaria}; margin-bottom: .5rem; }
-    .descricao { color: #555; font-size: 1rem; margin-bottom: 1.5rem; line-height: 1.5; }
+    h1 { font-size: 1.5rem; font-weight: 700; color: ${cfg.corPrimaria}; margin-bottom: .5rem; }
+    .descricao { color: #555; font-size: 0.95rem; margin-bottom: 1.25rem; line-height: 1.5; }
     .card {
       background: #f8f9fa;
       border-radius: 10px;
@@ -101,6 +110,22 @@ function renderizarPagina(cfg: PageConfig): string {
     }
     .card-row:last-child { border-bottom: none; }
     .label { color: #888; white-space: nowrap; }
+    .btn-confirmar {
+      display: block;
+      width: 100%;
+      background: ${cfg.corPrimaria};
+      color: #fff;
+      border: none;
+      border-radius: 12px;
+      padding: 0.95rem 1.5rem;
+      font-size: 1.05rem;
+      font-weight: 600;
+      cursor: pointer;
+      box-shadow: 0 2px 8px rgba(0,0,0,.12);
+      transition: opacity .15s ease, transform .1s ease;
+    }
+    .btn-confirmar:hover { opacity: .92; transform: translateY(-1px); }
+    .btn-confirmar:active { transform: translateY(0); }
     .badge {
       display: inline-block;
       margin-top: 1.5rem;
@@ -120,13 +145,45 @@ function renderizarPagina(cfg: PageConfig): string {
     <h1>${cfg.titulo}</h1>
     <p class="descricao">${cfg.descricao}</p>
     ${detalhesFolha}
-    <div class="badge">Ladesa</div>
+    ${botaoAcao}
   </div>
 </body>
 </html>`;
 }
 
-const PAGINAS: Record<
+// Configurações para a tela de confirmação (GET - antes de clicar)
+const TELAS_SOLICITACAO: Record<
+  FolhaPontoTokenTipo,
+  Omit<PageConfig, "data" | "horaInicio" | "horaFim" | "quantidadeHoras">
+> = {
+  [FolhaPontoTokenTipo.APROVACAO]: {
+    emoji: "📋",
+    titulo: "Aprovar Folha de Ponto",
+    descricao: "Revise os detalhes abaixo e confirme a aprovação do registro de ponto.",
+    corPrimaria: "#16a34a",
+    corFundo: "#f0fdf4",
+    botaoTexto: "✅ Confirmar Aprovação",
+  },
+  [FolhaPontoTokenTipo.REJEICAO]: {
+    emoji: "📋",
+    titulo: "Rejeitar Folha de Ponto",
+    descricao: "Revise os detalhes abaixo e confirme a rejeição do registro de ponto.",
+    corPrimaria: "#dc2626",
+    corFundo: "#fef2f2",
+    botaoTexto: "❌ Confirmar Rejeição",
+  },
+  [FolhaPontoTokenTipo.CANCELAMENTO]: {
+    emoji: "📋",
+    titulo: "Cancelar Solicitação",
+    descricao: "Revise os detalhes abaixo e confirme o cancelamento do registro de ponto.",
+    corPrimaria: "#9333ea",
+    corFundo: "#faf5ff",
+    botaoTexto: "↩️ Confirmar Cancelamento",
+  },
+};
+
+// Configurações para a tela de sucesso (POST - após clicar no botão)
+const TELAS_SUCESSO: Record<
   FolhaPontoTokenTipo,
   Omit<PageConfig, "data" | "horaInicio" | "horaFim" | "quantidadeHoras">
 > = {
@@ -176,9 +233,9 @@ export class FolhaPontoTokenRestController {
   ) {}
 
   /**
-   * Confirma a ação do supervisor via link do WhatsApp.
-   * Executa a ação imediatamente e retorna uma página HTML com o resultado.
-   * Endpoint público — sem autenticação JWT.
+   * Exibe a página de confirmação para o supervisor (GET).
+   * Operação segura e idempotente: não consome o token nem altera o banco.
+   * Evita que crawlers (como o preview de link do WhatsApp) executem ações acidentalmente.
    * GET /folha-ponto/tokens/:tokenId/confirmar
    */
   @Get("/:tokenId/confirmar")
@@ -186,26 +243,16 @@ export class FolhaPontoTokenRestController {
   @Header("Content-Type", "text/html; charset=utf-8")
   @Header("Cache-Control", "no-store")
   @ApiOperation({
-    operationId: "folhaPontoTokenConfirmarViaLink",
-    summary: "Confirma ação via link e retorna página HTML com o resultado",
+    operationId: "folhaPontoTokenExibirConfirmacao",
+    summary: "Exibe tela de confirmação da folha de ponto para o supervisor",
   })
-  @ApiOkResponse({ description: "Página HTML com resultado da ação" })
+  @ApiOkResponse({ description: "Página HTML com botão para confirmar ação" })
   @Throttle({ default: { limit: 10, ttl: 60000 } })
-  async confirmarViaLink(
-    @Param("tokenId", new ParseUUIDPipe()) tokenId: string,
-    @Req() req: Request,
-  ): Promise<string> {
-    const ip = (req.ip as string) ?? null;
-    const ua = (req.headers["user-agent"] as string) ?? null;
-
+  async exibirConfirmacao(@Param("tokenId", new ParseUUIDPipe()) tokenId: string): Promise<string> {
     try {
-      const {
-        acao,
-        folhaPontoId: _id,
-        folhaPonto,
-      } = await this.confirmHandler.confirmar(tokenId, ip, ua);
+      const { token, folhaPonto } = await this.confirmHandler.validar(tokenId);
 
-      const cfg = PAGINAS[acao];
+      const cfg = TELAS_SOLICITACAO[token.tipo];
       return renderizarPagina({
         ...cfg,
         data: folhaPonto.data,
@@ -220,8 +267,10 @@ export class FolhaPontoTokenRestController {
   }
 
   /**
-   * Confirma a ação do supervisor via POST (chamada programática).
-   * Endpoint público — autenticação via token one-time.
+   * Confirma a ação do supervisor (POST).
+   * Executa a mutação, consome o token e invalida os irmãos.
+   * Se chamado por navegador (HTML), retorna a página de sucesso.
+   * Se chamado programaticamente (JSON), retorna o payload JSON.
    * POST /folha-ponto/tokens/:tokenId/confirmar
    */
   @Post("/:tokenId/confirmar")
@@ -235,12 +284,43 @@ export class FolhaPontoTokenRestController {
   async confirmar(
     @Param("tokenId", new ParseUUIDPipe()) tokenId: string,
     @Req() req: Request,
-  ): Promise<{ sucesso: boolean; acao: string; folhaPontoId: string }> {
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<any> {
     const ip = (req.ip as string) ?? null;
     const ua = (req.headers["user-agent"] as string) ?? null;
+    const isJson = req.headers.accept?.includes("application/json") ?? false;
 
-    const { acao, folhaPontoId } = await this.confirmHandler.confirmar(tokenId, ip, ua);
+    try {
+      const { acao, folhaPontoId, folhaPonto } = await this.confirmHandler.confirmar(
+        tokenId,
+        ip,
+        ua,
+      );
 
-    return { sucesso: true, acao, folhaPontoId };
+      if (isJson) {
+        return { sucesso: true, acao, folhaPontoId };
+      }
+
+      res.setHeader("Content-Type", "text/html; charset=utf-8");
+      res.setHeader("Cache-Control", "no-store");
+
+      const cfg = TELAS_SUCESSO[acao];
+      return renderizarPagina({
+        ...cfg,
+        data: folhaPonto.data,
+        horaInicio: folhaPonto.horaInicio,
+        horaFim: folhaPonto.horaFim,
+        quantidadeHoras: folhaPonto.quantidadeHoras,
+      });
+    } catch (error: any) {
+      if (isJson) {
+        throw error;
+      }
+
+      res.setHeader("Content-Type", "text/html; charset=utf-8");
+      res.setHeader("Cache-Control", "no-store");
+      const mensagem: string = error?.message ?? "Ocorreu um erro ao processar este link.";
+      return renderizarPagina({ ...PAGINA_ERRO, descricao: mensagem });
+    }
   }
 }


### PR DESCRIPTION
…vent automatic approval by WhatsApp link preview crawlers

- GET /confirmar: displays confirmation preview page with timesheet details and confirmation button (read-only, does not consume token)
- POST /confirmar: executes approval/rejection/cancellation and renders success page (or returns JSON for API clients)
- Prevents WhatsApp / Telegram / Antivirus crawlers from auto-approving timesheets upon receiving links