### PR TITLE
chore(gitops): enable automated sync after drift gate

### DIFF
--- a/gitops/envs/development/applications/api.yaml
+++ b/gitops/envs/development/applications/api.yaml
@@ -21,6 +21,10 @@ spec:
     namespace: ladesa-ro-development
   revisionHistoryLimit: 3
   syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/gitops/envs/development/applications/waha.yaml
+++ b/gitops/envs/development/applications/waha.yaml
@@ -21,6 +21,10 @@ spec:
     namespace: ladesa-ro-development
   revisionHistoryLimit: 3
   syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true


### PR DESCRIPTION
O gate de drift zero passou nas duas Applications: `argocd app diff` saiu vazio em `ladesa-ro-api` e `ladesa-ro-waha` depois da adoção, e a adoção não reiniciou nenhum pod (mesmos ReplicaSets, 8h e 27h de idade, zero restart).

Com o gate satisfeito, o `automated` entra, que é o passo final do padrão documentado em [Repositórios satélite](https://github.com/ladesa-ro/infrastructure/blob/main/docs/arquitetura/satelites.md).

Os dois PVCs seguem sem o label `argocd.argoproj.io/instance`, então `prune: true` não os alcança. A sessão do WAHA não corre risco.