### PR TITLE
fix(queue): migrar schema bullmq automaticamente na conexão

### DIFF
--- a/src/infrastructure.message-broker/bullmq-queue.service.ts
+++ b/src/infrastructure.message-broker/bullmq-queue.service.ts
@@ -174,6 +174,7 @@ export class BullMqQueueService implements IQueueService, OnModuleInit, OnModule
       connection: {
         connectionString: opcoes.url,
         schema: opcoes.schema,
+        migrate: true,
       },
     };
   }


### PR DESCRIPTION
Achado ao acompanhar o deploy do `timetable-worker` na `ldsa`: o pod sobe e conecta, mas todo job falha com `BullMQ: PostgreSQL schema "bullmq" is not initialized`. O backend Postgres do BullMQ não migra o próprio schema sozinho a menos que `migrate: true` seja passado na conexão — nosso `#conexao()` nunca passava essa opção, então o schema nunca era criado em ambiente algum. `migrate: true` é a opção oficialmente suportada pelo BullMQ pra isso, idempotente, segura em toda conexão.