### PR TITLE
fix(queue): migrar schema bullmq também no worker standalone

### DIFF
--- a/src/infrastructure.timetable-generator/worker/index.ts
+++ b/src/infrastructure.timetable-generator/worker/index.ts
@@ -17,6 +17,7 @@ const conexao = {
   connection: {
     connectionString: config.bancoUrl,
     schema: config.schema,
+    migrate: true,
   },
 };
 


### PR DESCRIPTION
Continuação do #1086: aquele PR só corrigiu `bullmq-queue.service.ts` (usado pela API). O `timetable-worker` standalone (`worker/index.ts`) constrói sua própria conexão BullMQ, independente, e também não passava `migrate: true` — confirmado no pod real na `ldsa`, mesmo erro `schema "bullmq" is not initialized` persistindo depois do #1086 já mergeado e a imagem já atualizada.