### PR TITLE
feat(gitops): rollout de imagem via Argo CD Image Updater

### DIFF
--- a/.github/workflows/build-push.dev.yml
+++ b/.github/workflows/build-push.dev.yml
@@ -25,8 +25,9 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
+      contents: write
       packages: write
+      pull-requests: write
 
     steps:
       - name: "[CI] Checkout do código-fonte"
@@ -46,6 +47,7 @@ jobs:
           password: ${{ env.REGISTRY_TOKEN }}
 
       - name: "[CI] Construção e publicação da imagem de contêiner"
+        id: build-api
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./src/
@@ -64,6 +66,7 @@ jobs:
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_BASENAME }}/management-service:cache-development,mode=max
 
       - name: "[CI] Construção e publicação da imagem do timetable-worker"
+        id: build-timetable-worker
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./src/infrastructure.timetable-generator/
@@ -77,3 +80,37 @@ jobs:
           cache-to: |
             type=gha,scope=timetable-worker-dev,mode=max
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_BASENAME }}/timetable-worker:cache-development,mode=max
+
+      - name: "[CD] Abrir/atualizar PR de bump do digest no gitops"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DIGEST_API: ${{ steps.build-api.outputs.digest }}
+          DIGEST_TIMETABLE_WORKER: ${{ steps.build-timetable-worker.outputs.digest }}
+        run: |
+          BRANCH="chore/bump-image-management-service-development"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin main
+          git checkout -B "$BRANCH" origin/main
+
+          sed -i -E "s#^(\s*)(tag|digest): .*#\1digest: ${DIGEST_API}#" gitops/apps/api/values-development.yaml
+          sed -i -E "s#^(\s*)(tag|digest): .*#\1digest: ${DIGEST_TIMETABLE_WORKER}#" gitops/apps/timetable-worker/values-development.yaml
+
+          if git diff --quiet; then
+            echo "Digests iguais aos já registrados no gitops, nada a fazer."
+            exit 0
+          fi
+
+          git commit -am "chore(gitops): bump api e timetable-worker para novos digests"
+          git push --force origin "$BRANCH"
+
+          PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr edit "$PR_NUMBER" --body "Imagens publicadas por ${{ github.sha }}. api: ${DIGEST_API} · timetable-worker: ${DIGEST_TIMETABLE_WORKER}"
+          else
+            gh pr create --title "chore(gitops): bump management-service para novas imagens" \
+              --body "Imagens publicadas por ${{ github.sha }}. api: ${DIGEST_API} · timetable-worker: ${DIGEST_TIMETABLE_WORKER}" \
+              --base main --head "$BRANCH"
+          fi

--- a/.github/workflows/build-push.dev.yml
+++ b/.github/workflows/build-push.dev.yml
@@ -25,9 +25,8 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: read
       packages: write
-      pull-requests: write
 
     steps:
       - name: "[CI] Checkout do código-fonte"
@@ -47,7 +46,6 @@ jobs:
           password: ${{ env.REGISTRY_TOKEN }}
 
       - name: "[CI] Construção e publicação da imagem de contêiner"
-        id: build-api
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./src/
@@ -66,7 +64,6 @@ jobs:
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_BASENAME }}/management-service:cache-development,mode=max
 
       - name: "[CI] Construção e publicação da imagem do timetable-worker"
-        id: build-timetable-worker
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: ./src/infrastructure.timetable-generator/
@@ -80,37 +77,3 @@ jobs:
           cache-to: |
             type=gha,scope=timetable-worker-dev,mode=max
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_BASENAME }}/timetable-worker:cache-development,mode=max
-
-      - name: "[CD] Abrir/atualizar PR de bump do digest no gitops"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DIGEST_API: ${{ steps.build-api.outputs.digest }}
-          DIGEST_TIMETABLE_WORKER: ${{ steps.build-timetable-worker.outputs.digest }}
-        run: |
-          BRANCH="chore/bump-image-management-service-development"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git fetch origin main
-          git checkout -B "$BRANCH" origin/main
-
-          sed -i -E "s#^(\s*)(tag|digest): .*#\1digest: ${DIGEST_API}#" gitops/apps/api/values-development.yaml
-          sed -i -E "s#^(\s*)(tag|digest): .*#\1digest: ${DIGEST_TIMETABLE_WORKER}#" gitops/apps/timetable-worker/values-development.yaml
-
-          if git diff --quiet; then
-            echo "Digests iguais aos já registrados no gitops, nada a fazer."
-            exit 0
-          fi
-
-          git commit -am "chore(gitops): bump api e timetable-worker para novos digests"
-          git push --force origin "$BRANCH"
-
-          PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
-          if [ -n "$PR_NUMBER" ]; then
-            gh pr edit "$PR_NUMBER" --body "Imagens publicadas por ${{ github.sha }}. api: ${DIGEST_API} · timetable-worker: ${DIGEST_TIMETABLE_WORKER}"
-          else
-            gh pr create --title "chore(gitops): bump management-service para novas imagens" \
-              --body "Imagens publicadas por ${{ github.sha }}. api: ${DIGEST_API} · timetable-worker: ${DIGEST_TIMETABLE_WORKER}" \
-              --base main --head "$BRANCH"
-          fi

--- a/gitops/envs/development/applications/api.yaml
+++ b/gitops/envs/development/applications/api.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "0"
+    argocd-image-updater.argoproj.io/image-list: api=ghcr.io/ladesa-ro/management-service/management-service
+    argocd-image-updater.argoproj.io/api.update-strategy: digest
+    argocd-image-updater.argoproj.io/api.helm.image-tag: application.deployment.image.digest
+    argocd-image-updater.argoproj.io/write-back-method: argocd
 spec:
   project: ladesa-satellites
   source:

--- a/gitops/envs/development/applications/timetable-worker.yaml
+++ b/gitops/envs/development/applications/timetable-worker.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: timetable-worker=ghcr.io/ladesa-ro/management-service/timetable-worker
+    argocd-image-updater.argoproj.io/timetable-worker.update-strategy: digest
+    argocd-image-updater.argoproj.io/timetable-worker.helm.image-tag: application.deployment.image.digest
+    argocd-image-updater.argoproj.io/write-back-method: argocd
 spec:
   project: ladesa-satellites
   source:


### PR DESCRIPTION
## O que muda

Substitui o mecanismo de rollout de imagem: em vez do CI abrir um PR bumpando o digest no `values-development.yaml` (fricção real, ambiente `development` não deveria exigir aprovação humana pra atualizar sozinho), o Argo CD Image Updater passa a observar o registry e aplicar a atualização direto na `Application`, sem commit.

- `.github/workflows/build-push.dev.yml`: revertido pro original (o Image Updater não precisa de nenhum passo novo no CI).
- `gitops/envs/development/applications/api.yaml` e `timetable-worker.yaml`: anotações `argocd-image-updater.argoproj.io/*` (image-list, update-strategy digest, write-back-method argocd), uma `Application` cada.

Depende do PR companheiro em `ladesa-ro/infrastructure` que instala o Image Updater (referenciado ali).

## Test plan

- [x] YAML válido, `helm template` local confirmando que `application.deployment.image.digest` é aceito pelo chart.
- [ ] Depois que o Image Updater estiver rodando: confirmar que as duas `Application` refletem o digest atual e que um push novo atualiza os pods sozinho.