### PR TITLE
fix(gitops): forcar update do image updater, bug do argo cd deixa summary.images vazio

### DIFF
--- a/gitops/envs/development/applications/api.yaml
+++ b/gitops/envs/development/applications/api.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "0"
-    argocd-image-updater.argoproj.io/image-list: api=ghcr.io/ladesa-ro/management-service/management-service
+    argocd-image-updater.argoproj.io/image-list: api=ghcr.io/ladesa-ro/management-service/management-service:development
     argocd-image-updater.argoproj.io/api.update-strategy: digest
     argocd-image-updater.argoproj.io/api.helm.image-tag: application.deployment.image.digest
     argocd-image-updater.argoproj.io/api.force-update: "true"

--- a/gitops/envs/development/applications/api.yaml
+++ b/gitops/envs/development/applications/api.yaml
@@ -9,6 +9,7 @@ metadata:
     argocd-image-updater.argoproj.io/image-list: api=ghcr.io/ladesa-ro/management-service/management-service
     argocd-image-updater.argoproj.io/api.update-strategy: digest
     argocd-image-updater.argoproj.io/api.helm.image-tag: application.deployment.image.digest
+    argocd-image-updater.argoproj.io/api.force-update: "true"
     argocd-image-updater.argoproj.io/write-back-method: argocd
 spec:
   project: ladesa-satellites

--- a/gitops/envs/development/applications/timetable-worker.yaml
+++ b/gitops/envs/development/applications/timetable-worker.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "2"
-    argocd-image-updater.argoproj.io/image-list: timetable-worker=ghcr.io/ladesa-ro/management-service/timetable-worker
+    argocd-image-updater.argoproj.io/image-list: timetable-worker=ghcr.io/ladesa-ro/management-service/timetable-worker:development
     argocd-image-updater.argoproj.io/timetable-worker.update-strategy: digest
     argocd-image-updater.argoproj.io/timetable-worker.helm.image-tag: application.deployment.image.digest
     argocd-image-updater.argoproj.io/timetable-worker.force-update: "true"

--- a/gitops/envs/development/applications/timetable-worker.yaml
+++ b/gitops/envs/development/applications/timetable-worker.yaml
@@ -9,6 +9,7 @@ metadata:
     argocd-image-updater.argoproj.io/image-list: timetable-worker=ghcr.io/ladesa-ro/management-service/timetable-worker
     argocd-image-updater.argoproj.io/timetable-worker.update-strategy: digest
     argocd-image-updater.argoproj.io/timetable-worker.helm.image-tag: application.deployment.image.digest
+    argocd-image-updater.argoproj.io/timetable-worker.force-update: "true"
     argocd-image-updater.argoproj.io/write-back-method: argocd
 spec:
   project: ladesa-satellites


### PR DESCRIPTION
## Summary
- Argo CD Image Updater decide se uma imagem esta "live" lendo `Application.status.summary.images`. Nesse cluster esse campo esta vazio pra toda `Application` (nao so essas), um bug conhecido do proprio Argo CD, ver [argoproj/argo-cd#27861](https://github.com/argoproj/argo-cd/issues/27861) e [argoproj-labs/argocd-image-updater#791](https://github.com/argoproj-labs/argocd-image-updater/issues/791). Sem isso, o Image Updater sempre loga `"seems not to be live in this application, skipping"` e nunca atualiza nada, apesar de tudo mais (RBAC, project whitelist, anotacoes) estar correto.
- Mitigacao documentada pelo proprio mantenedor do Image Updater: `force-update: "true"`, que pula a checagem de liveness. Efeito colateral aceito: o Image Updater nao compara contra o digest atual, sempre reaplica o digest mais recente resolvido a cada ciclo (idempotente, sem novo rollout se o digest nao mudou de verdade, porque quem decide se reinicia o pod e o Argo CD comparando o manifesto renderizado, nao o Image Updater).

## Test plan
- [ ] Apos merge e proximo ciclo do Image Updater: log mostrando `Setting new image` em vez de `seems not to be live`, pra `api` e `timetable-worker`