### PR TITLE
feat: expor mudancaId na diferenca de horario-edicao e endpoint de carga maxima semanal

### DIFF
--- a/src/modules/acesso/usuario/perfil/application/commands/index.ts
+++ b/src/modules/acesso/usuario/perfil/application/commands/index.ts
@@ -2,3 +2,4 @@ export * from "./cargo-create.command.handler";
 export * from "./cargo-delete.command.handler";
 export * from "./cargo-update.command.handler";
 export * from "./perfil-definir-perfis-ativos.command.handler";
+export * from "./perfil-update.command.handler";

--- a/src/modules/acesso/usuario/perfil/application/commands/perfil-update.command.handler.spec.ts
+++ b/src/modules/acesso/usuario/perfil/application/commands/perfil-update.command.handler.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { ResourceNotFoundError } from "@/application/errors";
+import { createTestId } from "@/test/helpers";
+import { PerfilUpdateCommandHandlerImpl } from "./perfil-update.command.handler";
+
+function createPerfilQueryResult(overrides: Record<string, unknown> = {}) {
+  return {
+    id: createTestId(),
+    ativo: true,
+    cargo: { id: createTestId(), nome: "professor" },
+    campus: { id: createTestId() },
+    usuario: { id: createTestId() },
+    cargaMaximaSemanal: null,
+    dateCreated: "2026-01-01T00:00:00.000Z",
+    dateUpdated: "2026-01-01T00:00:00.000Z",
+    dateDeleted: null,
+    ...overrides,
+  };
+}
+
+describe("PerfilUpdateCommandHandlerImpl", () => {
+  it("updates cargaMaximaSemanal and persists the full domain-mapped payload", async () => {
+    const existente = createPerfilQueryResult();
+    const atualizado = createPerfilQueryResult({ cargaMaximaSemanal: 20 });
+
+    const repository = {
+      getFindOneQueryResult: vi
+        .fn()
+        .mockResolvedValueOnce(existente)
+        .mockResolvedValueOnce(atualizado),
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const handler = new PerfilUpdateCommandHandlerImpl(repository as never);
+
+    const result = await handler.execute(null, { id: existente.id, cargaMaximaSemanal: 20 });
+
+    expect(repository.update).toHaveBeenCalledWith(
+      existente.id,
+      expect.objectContaining({
+        ativo: true,
+        cargo: "professor",
+        campus: { id: existente.campus.id },
+        usuario: { id: existente.usuario.id },
+        cargaMaximaSemanal: 20,
+      }),
+    );
+    expect(result).toEqual(atualizado);
+  });
+
+  it("throws ResourceNotFoundError when the perfil does not exist", async () => {
+    const repository = {
+      getFindOneQueryResult: vi.fn().mockResolvedValue(null),
+      update: vi.fn(),
+    };
+
+    const handler = new PerfilUpdateCommandHandlerImpl(repository as never);
+
+    await expect(
+      handler.execute(null, { id: createTestId(), cargaMaximaSemanal: 10 }),
+    ).rejects.toThrow(ResourceNotFoundError);
+
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/acesso/usuario/perfil/application/commands/perfil-update.command.handler.ts
+++ b/src/modules/acesso/usuario/perfil/application/commands/perfil-update.command.handler.ts
@@ -1,0 +1,59 @@
+import { ensureExists } from "@/application/errors";
+import type { IAccessContext } from "@/domain/abstractions";
+import { Dep, Impl } from "@/domain/dependency-injection";
+import type { PerfilUpdateCommand } from "@/modules/acesso/usuario/perfil/domain/commands/perfil-update.command";
+import { IPerfilUpdateCommandHandler } from "@/modules/acesso/usuario/perfil/domain/commands/perfil-update.command.handler.interface";
+import { Perfil } from "@/modules/acesso/usuario/perfil/domain/perfil";
+import type {
+  PerfilFindOneQuery,
+  PerfilFindOneQueryResult,
+} from "@/modules/acesso/usuario/perfil/domain/queries";
+import { IPerfilRepository } from "@/modules/acesso/usuario/perfil/domain/repositories";
+
+@Impl()
+export class PerfilUpdateCommandHandlerImpl implements IPerfilUpdateCommandHandler {
+  constructor(
+    @Dep(IPerfilRepository)
+    private readonly repository: IPerfilRepository,
+  ) {}
+
+  async execute(
+    accessContext: IAccessContext | null,
+    dto: PerfilFindOneQuery & PerfilUpdateCommand,
+  ): Promise<PerfilFindOneQueryResult> {
+    const existente = await this.repository.getFindOneQueryResult(accessContext, { id: dto.id });
+    ensureExists(existente, Perfil.entityName, dto.id);
+
+    const domain = Perfil.load({
+      id: existente.id,
+      ativo: existente.ativo,
+      cargo: existente.cargo?.nome ?? "",
+      campus: { id: existente.campus.id },
+      usuario: { id: existente.usuario.id },
+      cargaMaximaSemanal: existente.cargaMaximaSemanal,
+      dateCreated: existente.dateCreated,
+      dateUpdated: existente.dateUpdated,
+      dateDeleted: existente.dateDeleted,
+    });
+
+    domain.update({
+      ativo: dto.ativo,
+      cargo: dto.cargo,
+      cargaMaximaSemanal: dto.cargaMaximaSemanal,
+    });
+
+    await this.repository.update(dto.id, {
+      ativo: domain.ativo,
+      cargo: domain.cargo,
+      campus: domain.campus,
+      usuario: domain.usuario,
+      cargaMaximaSemanal: domain.cargaMaximaSemanal,
+      dateUpdated: domain.dateUpdated,
+    });
+
+    const result = await this.repository.getFindOneQueryResult(accessContext, { id: dto.id });
+    ensureExists(result, Perfil.entityName, dto.id);
+
+    return result;
+  }
+}

--- a/src/modules/acesso/usuario/perfil/domain/commands/index.ts
+++ b/src/modules/acesso/usuario/perfil/domain/commands/index.ts
@@ -6,3 +6,5 @@ export * from "./cargo-update.command";
 export * from "./cargo-update.command.handler.interface";
 export * from "./perfil-definir-perfis-ativos.command";
 export * from "./perfil-definir-perfis-ativos.command.handler.interface";
+export * from "./perfil-update.command";
+export * from "./perfil-update.command.handler.interface";

--- a/src/modules/acesso/usuario/perfil/domain/commands/perfil-update.command.handler.interface.ts
+++ b/src/modules/acesso/usuario/perfil/domain/commands/perfil-update.command.handler.interface.ts
@@ -1,0 +1,16 @@
+import type { ICommandHandler } from "@/domain/abstractions";
+import { createOperationMetadata } from "@/domain/abstractions";
+import type { PerfilFindOneQuery, PerfilFindOneQueryResult } from "../queries";
+import type { PerfilUpdateCommand } from "./perfil-update.command";
+
+export const PerfilUpdateCommandMetadata = createOperationMetadata({
+  operationId: "perfilUpdate",
+  summary: "Atualiza um perfil (vinculo)",
+});
+
+export const IPerfilUpdateCommandHandler = Symbol("IPerfilUpdateCommandHandler");
+
+export type IPerfilUpdateCommandHandler = ICommandHandler<
+  PerfilFindOneQuery & PerfilUpdateCommand,
+  PerfilFindOneQueryResult
+>;

--- a/src/modules/acesso/usuario/perfil/domain/commands/perfil-update.command.ts
+++ b/src/modules/acesso/usuario/perfil/domain/commands/perfil-update.command.ts
@@ -1,0 +1,13 @@
+import { PerfilFields } from "../perfil.fields";
+
+export const PerfilUpdateCommandFields = {
+  ativo: PerfilFields.ativo,
+  cargo: PerfilFields.cargo,
+  cargaMaximaSemanal: PerfilFields.cargaMaximaSemanal,
+};
+
+export class PerfilUpdateCommand {
+  ativo?: boolean;
+  cargo?: string;
+  cargaMaximaSemanal?: number | null;
+}

--- a/src/modules/acesso/usuario/perfil/domain/queries/perfil-find-one.query.handler.interface.ts
+++ b/src/modules/acesso/usuario/perfil/domain/queries/perfil-find-one.query.handler.interface.ts
@@ -8,6 +8,11 @@ export const PerfilFindOneQueryMetadata = createOperationMetadata({
   summary: "Busca um perfil por ID",
 });
 
+export const PerfilFindOneByUsuarioQueryMetadata = createOperationMetadata({
+  operationId: "perfilFindByIdViaUsuario",
+  summary: "Busca um perfil de um usuario por ID",
+});
+
 export const IPerfilFindOneQueryHandler = Symbol("IPerfilFindOneQueryHandler");
 
 export type IPerfilFindOneQueryHandler = IQueryHandler<

--- a/src/modules/acesso/usuario/perfil/presentation.rest/perfil.rest.controller.ts
+++ b/src/modules/acesso/usuario/perfil/presentation.rest/perfil.rest.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Query } from "@nestjs/common";
+import { Body, Controller, Get, Param, Patch, Query } from "@nestjs/common";
 import {
   ApiForbiddenResponse,
   ApiNotFoundResponse,
@@ -8,9 +8,14 @@ import {
 } from "@nestjs/swagger";
 import type { IAccessContext } from "@/domain/abstractions";
 import { Dep } from "@/domain/dependency-injection";
+import {
+  IPerfilUpdateCommandHandler,
+  PerfilUpdateCommandMetadata,
+} from "@/modules/acesso/usuario/perfil/domain/commands/perfil-update.command.handler.interface";
 import { PerfilEnsinoByIdQueryMetadata } from "@/modules/acesso/usuario/perfil/domain/queries/perfil-ensino-by-id.query.metadata";
 import {
   IPerfilFindOneQueryHandler,
+  PerfilFindOneByUsuarioQueryMetadata,
   PerfilFindOneQueryMetadata,
 } from "@/modules/acesso/usuario/perfil/domain/queries/perfil-find-one.query.handler.interface";
 import {
@@ -28,6 +33,7 @@ import {
   PerfilFindOneOutputRestDto,
   PerfilListInputRestDto,
   PerfilListOutputRestDto,
+  PerfilUpdateInputRestDto,
   PerfilVinculosFiltroInputRestDto,
 } from "./perfil.rest.dto";
 import * as PerfilRestMapper from "./perfil.rest.mapper";
@@ -42,6 +48,8 @@ export class PerfilListRestController {
     private readonly findOneHandler: IPerfilFindOneQueryHandler,
     @Dep(IPerfilVinculosFiltroQueryHandler)
     private readonly vinculosFiltroHandler: IPerfilVinculosFiltroQueryHandler,
+    @Dep(IPerfilUpdateCommandHandler)
+    private readonly updateHandler: IPerfilUpdateCommandHandler,
   ) {}
 
   @Get("/")
@@ -87,6 +95,21 @@ export class PerfilListRestController {
     const queryResult = await this.findOneHandler.execute(accessContext, query);
     return queryResult ? PerfilRestMapper.findOneQueryResultToOutputDto.map(queryResult) : null;
   }
+
+  @Patch("/:id")
+  @ApiOperation(PerfilUpdateCommandMetadata.swaggerMetadata)
+  @ApiOkResponse({ type: PerfilFindOneOutputRestDto })
+  @ApiForbiddenResponse()
+  @ApiNotFoundResponse()
+  async update(
+    @AccessContextHttp() accessContext: IAccessContext,
+    @Param() params: PerfilFindOneInputRestDto,
+    @Body() dto: PerfilUpdateInputRestDto,
+  ): Promise<PerfilFindOneOutputRestDto> {
+    const command = PerfilRestMapper.updateInputDtoToUpdateCommand.map({ params, dto });
+    const queryResult = await this.updateHandler.execute(accessContext, command);
+    return PerfilRestMapper.findOneQueryResultToOutputDto.map(queryResult);
+  }
 }
 
 @ApiTags("usuarios")
@@ -98,7 +121,7 @@ export class PerfilRestController {
   ) {}
 
   @Get("/:id")
-  @ApiOperation(PerfilFindOneQueryMetadata.swaggerMetadata)
+  @ApiOperation(PerfilFindOneByUsuarioQueryMetadata.swaggerMetadata)
   @ApiOkResponse({ type: PerfilFindOneOutputRestDto })
   @ApiForbiddenResponse()
   @ApiNotFoundResponse()

--- a/src/modules/acesso/usuario/perfil/presentation.rest/perfil.rest.dto.ts
+++ b/src/modules/acesso/usuario/perfil/presentation.rest/perfil.rest.dto.ts
@@ -1,3 +1,5 @@
+import { PerfilUpdateCommandFields } from "@/modules/acesso/usuario/perfil/domain/commands/perfil-update.command";
+import { PerfilUpdateSchema } from "@/modules/acesso/usuario/perfil/domain/perfil.schemas";
 import { PerfilFindOneQueryFields } from "@/modules/acesso/usuario/perfil/domain/queries/perfil-find-one.query";
 import { PerfilFindOneQueryResultFields } from "@/modules/acesso/usuario/perfil/domain/queries/perfil-find-one.query.result";
 import { PerfilFindOneInputSchema } from "@/modules/acesso/usuario/perfil/domain/queries/perfil-find-one.query.schemas";
@@ -55,6 +57,24 @@ export class PerfilFindOneInputRestDto {
 
   @ApiProperty(PerfilFindOneQueryFields.id.swaggerMetadata)
   id: string;
+}
+
+// ============================================================================
+// Update Input
+// ============================================================================
+
+@ApiSchema({ name: "PerfilUpdateInputDto" })
+export class PerfilUpdateInputRestDto {
+  static schema = PerfilUpdateSchema.presentation;
+
+  @ApiPropertyOptional(PerfilUpdateCommandFields.ativo.swaggerMetadata)
+  ativo?: boolean;
+
+  @ApiPropertyOptional(PerfilUpdateCommandFields.cargo.swaggerMetadata)
+  cargo?: string;
+
+  @ApiPropertyOptional(PerfilUpdateCommandFields.cargaMaximaSemanal.swaggerMetadata)
+  cargaMaximaSemanal?: number | null;
 }
 
 // ============================================================================

--- a/src/modules/acesso/usuario/perfil/presentation.rest/perfil.rest.mapper.ts
+++ b/src/modules/acesso/usuario/perfil/presentation.rest/perfil.rest.mapper.ts
@@ -3,6 +3,7 @@ import {
   type PerfilFindOneQueryResult,
   PerfilListQuery,
 } from "@/modules/acesso/usuario/perfil";
+import type { PerfilUpdateCommand } from "@/modules/acesso/usuario/perfil/domain/commands/perfil-update.command";
 import * as UsuarioRestMapper from "@/modules/acesso/usuario/presentation.rest/usuario.rest.mapper";
 import * as CampusRestMapper from "@/modules/ambientes/campus/presentation.rest/campus.rest.mapper";
 import { createListMapper, createMapper, createPaginatedInputMapper, into } from "@/shared/mapping";
@@ -10,6 +11,7 @@ import {
   PerfilFindOneOutputRestDto,
   type PerfilListInputRestDto,
   PerfilListOutputRestDto,
+  type PerfilUpdateInputRestDto,
 } from "./perfil.rest.dto";
 
 // ============================================================================
@@ -23,6 +25,16 @@ export const findOneInputDtoToFindOneQuery = createMapper<{ id: string }, Perfil
     return input;
   },
 );
+
+export const updateInputDtoToUpdateCommand = createMapper<
+  { params: { id: string }; dto: PerfilUpdateInputRestDto },
+  PerfilFindOneQuery & PerfilUpdateCommand
+>(({ params, dto }) => ({
+  id: params.id,
+  ativo: dto.ativo,
+  cargo: dto.cargo,
+  cargaMaximaSemanal: dto.cargaMaximaSemanal,
+}));
 
 export const listInputDtoToListQuery = createPaginatedInputMapper<
   PerfilListInputRestDto,

--- a/src/modules/acesso/usuario/usuario.module.ts
+++ b/src/modules/acesso/usuario/usuario.module.ts
@@ -50,6 +50,7 @@ import {
   CargoDeleteCommandHandlerImpl,
   CargoUpdateCommandHandlerImpl,
   PerfilDefinirPerfisAtivosCommandHandlerImpl,
+  PerfilUpdateCommandHandlerImpl,
 } from "@/modules/acesso/usuario/perfil/application/commands";
 import {
   CargoFindOneQueryHandlerImpl,
@@ -64,6 +65,7 @@ import {
   ICargoDeleteCommandHandler,
   ICargoUpdateCommandHandler,
   IPerfilDefinirPerfisAtivosCommandHandler,
+  IPerfilUpdateCommandHandler,
 } from "@/modules/acesso/usuario/perfil/domain/commands";
 import {
   ICargoFindOneQueryHandler,
@@ -168,6 +170,7 @@ import { TurmaModule } from "@/modules/ensino/turma/turma.module";
     { provide: IPerfilFindOneQueryHandler, useClass: PerfilFindOneQueryHandlerImpl },
     { provide: IPerfilFindAllActiveQueryHandler, useClass: PerfilFindAllActiveQueryHandlerImpl },
     { provide: IPerfilVinculosFiltroQueryHandler, useClass: PerfilVinculosFiltroQueryHandlerImpl },
+    { provide: IPerfilUpdateCommandHandler, useClass: PerfilUpdateCommandHandlerImpl },
   ],
   exports: [
     IUsuarioFindOneQueryHandler,

--- a/src/modules/calendario/horario-edicao/application/queries/horario-edicao-sessao-diferenca.query.handler.spec.ts
+++ b/src/modules/calendario/horario-edicao/application/queries/horario-edicao-sessao-diferenca.query.handler.spec.ts
@@ -143,6 +143,7 @@ describe("HorarioEdicaoSessaoDiferencaQueryHandlerImpl", () => {
 
     expect(result.entram).toEqual([
       {
+        mudancaId: mudancaCriar.id,
         tipoOperacao: HorarioEdicaoMudancaTipoOperacao.CRIAR,
         calendarioAgendamentoId: null,
         antes: null,
@@ -152,6 +153,7 @@ describe("HorarioEdicaoSessaoDiferencaQueryHandlerImpl", () => {
 
     expect(result.mudam).toEqual([
       {
+        mudancaId: mudancaMover.id,
         tipoOperacao: HorarioEdicaoMudancaTipoOperacao.MOVER,
         calendarioAgendamentoId: moverAgendamentoId,
         antes: { horarioInicio: "09:00:00" },
@@ -161,6 +163,7 @@ describe("HorarioEdicaoSessaoDiferencaQueryHandlerImpl", () => {
 
     expect(result.saem).toEqual([
       {
+        mudancaId: mudancaRemover.id,
         tipoOperacao: HorarioEdicaoMudancaTipoOperacao.REMOVER,
         calendarioAgendamentoId: removerAgendamentoId,
         antes: { nome: "Sera removido" },
@@ -205,6 +208,7 @@ describe("HorarioEdicaoSessaoDiferencaQueryHandlerImpl", () => {
 
     expect(result.mudam).toEqual([
       {
+        mudancaId: mudancaMover.id,
         tipoOperacao: HorarioEdicaoMudancaTipoOperacao.MOVER,
         calendarioAgendamentoId: agendamentoId,
         antes: {

--- a/src/modules/calendario/horario-edicao/application/queries/horario-edicao-sessao-diferenca.query.handler.ts
+++ b/src/modules/calendario/horario-edicao/application/queries/horario-edicao-sessao-diferenca.query.handler.ts
@@ -44,6 +44,7 @@ export class HorarioEdicaoSessaoDiferencaQueryHandlerImpl
       switch (mudanca.tipoOperacao) {
         case HorarioEdicaoMudancaTipoOperacao.CRIAR:
           resultado.entram.push({
+            mudancaId: mudanca.id,
             tipoOperacao: HorarioEdicaoMudancaTipoOperacao.CRIAR,
             calendarioAgendamentoId: mudanca.calendarioAgendamento?.id ?? null,
             antes: null,
@@ -53,6 +54,7 @@ export class HorarioEdicaoSessaoDiferencaQueryHandlerImpl
 
         case HorarioEdicaoMudancaTipoOperacao.REMOVER:
           resultado.saem.push({
+            mudancaId: mudanca.id,
             tipoOperacao: HorarioEdicaoMudancaTipoOperacao.REMOVER,
             calendarioAgendamentoId: mudanca.calendarioAgendamento?.id ?? null,
             antes: await this.resolverEstadoAnterior(accessContext, mudanca),
@@ -62,6 +64,7 @@ export class HorarioEdicaoSessaoDiferencaQueryHandlerImpl
 
         case HorarioEdicaoMudancaTipoOperacao.MOVER:
           resultado.mudam.push({
+            mudancaId: mudanca.id,
             tipoOperacao: HorarioEdicaoMudancaTipoOperacao.MOVER,
             calendarioAgendamentoId: mudanca.calendarioAgendamento?.id ?? null,
             antes: await this.resolverEstadoAnterior(accessContext, mudanca),

--- a/src/modules/calendario/horario-edicao/domain/horario-edicao.operations.ts
+++ b/src/modules/calendario/horario-edicao/domain/horario-edicao.operations.ts
@@ -5,6 +5,11 @@ export const HorarioEdicaoCreateCommandMetadata = createOperationMetadata({
   summary: "Cria nova sessao de edicao de horario",
 });
 
+export const HorarioEdicaoFindOneQueryMetadata = createOperationMetadata({
+  operationId: "horarioEdicaoFindOne",
+  summary: "Busca uma sessao de edicao de horario por id",
+});
+
 export const HorarioEdicaoApplyChangeCommandMetadata = createOperationMetadata({
   operationId: "horarioEdicaoApplyChange",
   summary: "Aplica uma mudanca a sessao de edicao de horario",
@@ -13,6 +18,11 @@ export const HorarioEdicaoApplyChangeCommandMetadata = createOperationMetadata({
 export const HorarioEdicaoSalvarCommandMetadata = createOperationMetadata({
   operationId: "horarioEdicaoSalvar",
   summary: "Salva sessao de edicao permanentemente",
+});
+
+export const HorarioEdicaoPublicarCommandMetadata = createOperationMetadata({
+  operationId: "horarioEdicaoPublicar",
+  summary: "Publica as mudancas da sessao de edicao no calendario oficial",
 });
 
 export const HorarioEdicaoCancelarCommandMetadata = createOperationMetadata({

--- a/src/modules/calendario/horario-edicao/domain/queries/horario-edicao-sessao-diferenca.query.result.ts
+++ b/src/modules/calendario/horario-edicao/domain/queries/horario-edicao-sessao-diferenca.query.result.ts
@@ -1,4 +1,5 @@
 export interface IHorarioEdicaoDiferencaEntrada {
+  mudancaId: string;
   tipoOperacao: "CRIAR" | "MOVER" | "REMOVER";
   calendarioAgendamentoId: string | null;
   antes: Record<string, unknown> | null;

--- a/src/modules/calendario/horario-edicao/presentation.rest/horario-edicao.rest.controller.ts
+++ b/src/modules/calendario/horario-edicao/presentation.rest/horario-edicao.rest.controller.ts
@@ -34,6 +34,8 @@ import {
   HorarioEdicaoCancelarCommandMetadata,
   HorarioEdicaoCreateCommandMetadata,
   HorarioEdicaoDesfazerMudancaCommandMetadata,
+  HorarioEdicaoFindOneQueryMetadata,
+  HorarioEdicaoPublicarCommandMetadata,
   HorarioEdicaoSalvarCommandMetadata,
 } from "../domain/horario-edicao.operations";
 import {
@@ -143,6 +145,21 @@ export class HorarioEdicaoRestController {
     return this.toSessaoOutput(saved);
   }
 
+  @Get("/:sessaoId")
+  @ApiOperation(HorarioEdicaoFindOneQueryMetadata.swaggerMetadata)
+  @ApiOkResponse({ type: HorarioEdicaoSessaoOutputRestDto })
+  @ApiForbiddenResponse()
+  @ApiNotFoundResponse()
+  async findOne(
+    @AccessContextHttp() _accessContext: IAccessContext,
+    @Param() params: HorarioEdicaoSessaoParamsRestDto,
+  ): Promise<HorarioEdicaoSessaoOutputRestDto> {
+    const sessao = await this.sessaoRepository.findById(params.sessaoId);
+    ensureExists(sessao, "HorarioEdicaoSessao", params.sessaoId);
+
+    return this.toSessaoOutput(sessao);
+  }
+
   @Patch("/:sessaoId")
   @ApiOperation(HorarioEdicaoApplyChangeCommandMetadata.swaggerMetadata)
   @ApiOkResponse({ type: HorarioEdicaoMudancaOutputRestDto })
@@ -246,7 +263,7 @@ export class HorarioEdicaoRestController {
   }
 
   @Post("/:sessaoId/publicar")
-  @ApiOperation(HorarioEdicaoSalvarCommandMetadata.swaggerMetadata)
+  @ApiOperation(HorarioEdicaoPublicarCommandMetadata.swaggerMetadata)
   @ApiOkResponse({ type: HorarioEdicaoSessaoOutputRestDto })
   @ApiForbiddenResponse()
   @ApiNotFoundResponse()
@@ -288,6 +305,7 @@ export class HorarioEdicaoRestController {
     entrada: IHorarioEdicaoDiferencaEntrada,
   ): HorarioEdicaoDiferencaEntradaOutputRestDto {
     const dto = new HorarioEdicaoDiferencaEntradaOutputRestDto();
+    dto.mudancaId = entrada.mudancaId;
     dto.tipoOperacao = entrada.tipoOperacao;
     dto.calendarioAgendamentoId = entrada.calendarioAgendamentoId;
     dto.antes = entrada.antes;

--- a/src/modules/calendario/horario-edicao/presentation.rest/horario-edicao.rest.dto.ts
+++ b/src/modules/calendario/horario-edicao/presentation.rest/horario-edicao.rest.dto.ts
@@ -68,6 +68,9 @@ export class HorarioEdicaoMudancaOutputRestDto {
 }
 
 export class HorarioEdicaoDiferencaEntradaOutputRestDto {
+  @ApiProperty()
+  mudancaId!: string;
+
   @ApiProperty({ enum: HorarioEdicaoMudancaTipoOperacao })
   tipoOperacao!: "CRIAR" | "MOVER" | "REMOVER";
 


### PR DESCRIPTION
## Summary
- `horario-edicao`: expoe `mudancaId` na diferenca de sessao e adiciona GET isolado da sessao.
- `perfil`: novo endpoint de update para `cargaMaximaSemanal`.

## Test plan
- [x] Testes unitarios inclusos nos dois commits