### PR TITLE
fix(gitops): apontar helm.image-tag pro campo tag, nao digest

### DIFF
--- a/gitops/envs/development/applications/api.yaml
+++ b/gitops/envs/development/applications/api.yaml
@@ -8,7 +8,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     argocd-image-updater.argoproj.io/image-list: api=ghcr.io/ladesa-ro/management-service/management-service:development
     argocd-image-updater.argoproj.io/api.update-strategy: digest
-    argocd-image-updater.argoproj.io/api.helm.image-tag: application.deployment.image.digest
+    argocd-image-updater.argoproj.io/api.helm.image-tag: application.deployment.image.tag
     argocd-image-updater.argoproj.io/api.force-update: "true"
     argocd-image-updater.argoproj.io/write-back-method: argocd
 spec:

--- a/gitops/envs/development/applications/timetable-worker.yaml
+++ b/gitops/envs/development/applications/timetable-worker.yaml
@@ -8,7 +8,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
     argocd-image-updater.argoproj.io/image-list: timetable-worker=ghcr.io/ladesa-ro/management-service/timetable-worker:development
     argocd-image-updater.argoproj.io/timetable-worker.update-strategy: digest
-    argocd-image-updater.argoproj.io/timetable-worker.helm.image-tag: application.deployment.image.digest
+    argocd-image-updater.argoproj.io/timetable-worker.helm.image-tag: application.deployment.image.tag
     argocd-image-updater.argoproj.io/timetable-worker.force-update: "true"
     argocd-image-updater.argoproj.io/write-back-method: argocd
 spec:


### PR DESCRIPTION
## Summary
Achado ao vivo: pods novos de `api` e `timetable-worker` ficaram `InvalidImageName`, imagem renderizando com `tag` duplicada (`...:development@development@sha256:...`).

Causa raiz: o Image Updater sempre escreve o valor combinado `tag@digest` no parametro apontado por `helm.image-tag` (`SetHelmImage`/`GetTagWithDigest()` em `pkg/argocd/argocd.go`). O chart `stakater/application` monta a imagem a partir de dois campos separados, `tag` e `digest`. Apontar pro campo `.digest` duplicava o `tag` estatico.

Corrigido apontando pro campo `.tag`.

## Test plan
- [ ] Apos merge: limpar o parametro `application.deployment.image.digest` (ficou com valor errado) nas duas Applications, esperar o Image Updater reescrever via `.tag`, confirmar pods `Running`