### PR TITLE
fix(deps): fixar keycloak-admin-client em 26.6.4, regressao na 26.7.x

### DIFF
--- a/src/bun.lock
+++ b/src/bun.lock
@@ -9,7 +9,7 @@
         "@apollo/utils.keyvaluecache": "^4.0.0",
         "@as-integrations/express5": "^1.1.2",
         "@bufbuild/protobuf": "^2.2.5",
-        "@keycloak/keycloak-admin-client": "^26.7.1",
+        "@keycloak/keycloak-admin-client": "26.6.4",
         "@nestjs/apollo": "^13.4.4",
         "@nestjs/axios": "^4.0.1",
         "@nestjs/common": "^11.1.29",
@@ -293,7 +293,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@keycloak/keycloak-admin-client": ["@keycloak/keycloak-admin-client@26.7.1", "", { "dependencies": { "@microsoft/kiota-abstractions": "1.0.0-preview.103", "@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.103", "@microsoft/kiota-serialization-form": "1.0.0-preview.103", "@microsoft/kiota-serialization-json": "1.0.0-preview.103", "@microsoft/kiota-serialization-multipart": "1.0.0-preview.103", "@microsoft/kiota-serialization-text": "1.0.0-preview.103", "camelize-ts": "^3.0.0", "url-template": "^3.1.1" } }, "sha512-jKJ+xR6SxoIDY3LjThmLGkeJJGA4LaihqieJOd/qnVIUfNMsUjmwWNOomPAEH+TUfRz6CG9yiuxxvauuM1KmIQ=="],
+    "@keycloak/keycloak-admin-client": ["@keycloak/keycloak-admin-client@26.6.4", "", { "dependencies": { "@microsoft/kiota-abstractions": "^1.0.0-preview.86", "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.80", "@microsoft/kiota-serialization-form": "^1.0.0-preview.74", "@microsoft/kiota-serialization-json": "^1.0.0-preview.86", "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.67", "@microsoft/kiota-serialization-text": "^1.0.0-preview.79", "camelize-ts": "^3.0.0", "url-template": "^3.1.1" } }, "sha512-Jd8Ah3p4yK3SX8e35buzHACMKnN1h7upDZotM1kibnqKvW3Nj+Vjm2/pgFP/v1Qk0IZIVO5oMoB47w+wlgcuoA=="],
 
     "@lukeed/csprng": ["@lukeed/csprng@1.1.0", "", {}, "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA=="],
 

--- a/src/package.json
+++ b/src/package.json
@@ -6,7 +6,7 @@
     "@apollo/server": "^5.5.1",
     "@apollo/utils.keyvaluecache": "^4.0.0",
     "@as-integrations/express5": "^1.1.2",
-    "@keycloak/keycloak-admin-client": "^26.7.1",
+    "@keycloak/keycloak-admin-client": "26.6.4",
     "@nestjs/apollo": "^13.4.4",
     "@nestjs/axios": "^4.0.1",
     "@nestjs/common": "^11.1.29",


### PR DESCRIPTION
## Summary
Achado ao vivo: login quebrado em producao, API presa num loop de reconexao com o Keycloak, `TypeError: undefined is not an object (evaluating 'token.split')`.

Causa raiz, 100% upstream, confirmada lendo o historico do `keycloak/keycloak` (monorepo onde vive o `@keycloak/keycloak-admin-client`):

1. [PR #46185](https://github.com/keycloak/keycloak/pull/46185) (2026-02-13) adicionou `token?.split(".") || []` em `decode.js`, porque `token` pode vir `undefined` (grant `client_credentials`, usado por este servico pra se autenticar, nao retorna `refresh_token`, comportamento OAuth2 padrao, nao erro).
2. [Commit d8966841](https://github.com/keycloak/keycloak/commit/d8966841) (2026-05-12, PR #48218 "Enable no-unnecessary-condition ESLint rule") reintroduziu o bug sem querer: o linter viu o tipo TS declarado como `token: string` e removeu o `?.` como "desnecessario", ignorando que em runtime o valor pode ser `undefined`.
3. [PR #51985](https://github.com/keycloak/keycloak/pull/51985) (2026-08-24, "Regression in UI in JS keycloak-admin-client") corrige de novo, mas **ainda nao foi publicado no npm**. Ultima versao publicada e `26.7.2` (19/08), 5 dias antes do fix mergear upstream.

O Dependabot bumpou `26.6.2` -> `26.7.1` no PR #1090 (grupo de 20 updates de uma vez), mergeado ontem, carregando a regressao pra este repositorio. CI nao pegou porque nao testa login real contra Keycloak.

Fix: `26.6.4` (ultima release da linha 26.6.x, publicada em junho, antes da regressao se propagar pra essa branch) confirmada com o `?.` intacto. Fixada sem caret (`"26.6.4"`, nao `"^26.6.4"`) de proposito, pra o Dependabot nao bumpar de volta pra 26.7.x sem revisao manual ate o fix upstream ser publicado.

## Test plan
- [x] `decodeToken(undefined)` retorna `{}` em vez de lancar `TypeError` (testado isolado com bun)
- [x] `bun --bun run typecheck` limpo
- [ ] Apos merge e deploy: login funcionando de verdade em producao