### PR TITLE
fix(calendario): adicionar colunas faltantes em calendario_letivo_dia

### DIFF
--- a/src/infrastructure.database/migrations/2026082800000-add-missing-columns-to-calendario-letivo-dia.ts
+++ b/src/infrastructure.database/migrations/2026082800000-add-missing-columns-to-calendario-letivo-dia.ts
@@ -1,0 +1,42 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+export class AddMissingColumnsToCalendarioLetivoDia2026082800000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      "calendario_letivo_dia",
+      new TableColumn({
+        name: "dia_presencial",
+        type: "boolean",
+        isNullable: false,
+        default: false,
+      }),
+    );
+
+    await queryRunner.addColumn(
+      "calendario_letivo_dia",
+      new TableColumn({
+        name: "tipo",
+        type: "varchar",
+        length: "50",
+        isNullable: false,
+        default: "'Outro'",
+      }),
+    );
+
+    await queryRunner.addColumn(
+      "calendario_letivo_dia",
+      new TableColumn({
+        name: "extra_curricular",
+        type: "boolean",
+        isNullable: false,
+        default: false,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn("calendario_letivo_dia", "extra_curricular");
+    await queryRunner.dropColumn("calendario_letivo_dia", "tipo");
+    await queryRunner.dropColumn("calendario_letivo_dia", "dia_presencial");
+  }
+}


### PR DESCRIPTION
## Summary
Achado ao vivo: erro 500 em `POST /api/v1/gerar-horario`, `error: column CalendarioLetivoDiaEntity.dia_presencial does not exist`.

Comparei a entidade `CalendarioLetivoDiaEntity` com o schema real da tabela `calendario_letivo_dia` em producao: faltam 3 colunas que a entidade declara ha tempo (`dia_presencial`, `tipo`, `extra_curricular`), nenhuma migration jamais as criou (`git log -S "dia_presencial"` so acha o commit de reorganizacao de pastas, nunca uma migration real). Tabela confirmada vazia em producao (0 linhas), entao a migration e segura, sem necessidade de backfill.

## Test plan
- [x] `bun --bun run typecheck` limpo
- [ ] Apos merge e deploy: `POST /api/v1/gerar-horario` sem erro 500