### PR TITLE
fix(calendario): adicionar valores faltantes ao enum gerar_horario_status

### DIFF
--- a/src/infrastructure.database/migrations/2026082800001-add-missing-values-to-gerar-horario-status.ts
+++ b/src/infrastructure.database/migrations/2026082800001-add-missing-values-to-gerar-horario-status.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddMissingValuesToGerarHorarioStatus2026082800001 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TYPE "gerar_horario_status" ADD VALUE IF NOT EXISTS 'ACEITO'`);
+    await queryRunner.query(`ALTER TYPE "gerar_horario_status" ADD VALUE IF NOT EXISTS 'REJEITADO'`);
+  }
+
+  public async down(): Promise<void> {
+    // PostgreSQL não suporta remover valor de enum. Reverter exigiria recriar o tipo
+    // do zero (criar novo tipo sem os valores, migrar a coluna, apagar o tipo antigo),
+    // arriscado se alguma linha já usa "ACEITO"/"REJEITADO". Sem down por decisao.
+  }
+}


### PR DESCRIPTION
## Summary
Segundo erro 500 achado ao vivo em `POST /api/v1/gerar-horario`, depois do fix das colunas de calendario_letivo_dia (#1107): `error: invalid input value for enum gerar_horario_status: "ACEITO"`.

Mesmo padrao de drift: o enum de dominio `GerarHorarioStatus` tem 6 valores (SOLICITADO, PENDENTE, SUCESSO, ERRO, ACEITO, REJEITADO), o tipo `gerar_horario_status` no Postgres so tem os 4 originais da migration de criacao (1742517210000). `ACEITO` e `REJEITADO` foram adicionados ao codigo em algum momento sem a migration correspondente.

Varri todos os outros enums do modulo `calendario` (11 colunas `type: "enum"` em 8 entidades) comparando codigo com `pg_enum` ao vivo: todos os outros batem exatamente, esse foi o unico com drift.

`ALTER TYPE ... ADD VALUE` nao pode ser revertido de forma segura (Postgres nao suporta remover valor de enum sem recriar o tipo do zero), `down()` fica vazio por decisao, comentado o porque.

## Test plan
- [x] `bun --bun run typecheck` limpo
- [x] Todos os outros enums do modulo calendario conferidos contra o banco, sem drift adicional
- [ ] Apos merge e deploy: `POST /api/v1/gerar-horario` completando com status `ACEITO`/`REJEITADO` sem erro 500