### PR TITLE
fix(calendario): aninhar campos de gerar-horario em generate_request

### DIFF
--- a/src/modules/calendario/gerar-horario/application/commands/gerar-horario-create.command.handler.ts
+++ b/src/modules/calendario/gerar-horario/application/commands/gerar-horario-create.command.handler.ts
@@ -58,17 +58,19 @@ export class GerarHorarioCreateCommandHandlerImpl implements IGerarHorarioCreate
 
     const request = {
       request_id: domain.id,
-      ...escopo,
+      generate_request: {
+        ...escopo,
 
-      boost_same_day_of_week_and_time_slot: command.boostSameDayOfWeekAndTimeSlot ?? 0,
-      boost_same_day_of_week_only: command.boostSameDayOfWeekOnly ?? 0,
-      boost_same_time_slot_only: command.boostSameTimeSlotOnly ?? 0,
-      boost_lesser_distance_from_day_of_week: command.boostLesserDistanceFromDayOfWeek ?? 0,
-      boost_lesser_distance_from_time_slot: command.boostLesserDistanceFromTimeSlot ?? 0,
+        boost_same_day_of_week_and_time_slot: command.boostSameDayOfWeekAndTimeSlot ?? 0,
+        boost_same_day_of_week_only: command.boostSameDayOfWeekOnly ?? 0,
+        boost_same_time_slot_only: command.boostSameTimeSlotOnly ?? 0,
+        boost_lesser_distance_from_day_of_week: command.boostLesserDistanceFromDayOfWeek ?? 0,
+        boost_lesser_distance_from_time_slot: command.boostLesserDistanceFromTimeSlot ?? 0,
 
-      enabled_constraints: command.enabledConstraints
-        ? { kinds: command.enabledConstraints }
-        : null,
+        enabled_constraints: command.enabledConstraints
+          ? { kinds: command.enabledConstraints }
+          : null,
+      },
     };
 
     await this.messageBrokerService.publishTimetableRequestFireAndForget(request, domain.id);


### PR DESCRIPTION
## Summary
Terceiro erro achado ao vivo na mesma investigacao de `POST /api/v1/gerar-horario`, depois dos fixes de schema (#1107, #1109): a geracao chegava a rodar, mas sempre retornava `status: ERRO`, `GEN-0002-MAP: Erro ao tentar converter request para dto. Object reference not set to an instance of an object.`, vindo do lado C# do gerador (nao do management-service).

Causa raiz: `ServiceGenerateRequest` (proto) tem dois campos, `request_id` e `generate_request` (mensagem aninhada com todos os dados da geracao). O handler montava o payload espalhando (`...escopo`) os campos direto no mesmo nivel de `request_id`, nunca aninhando em `generate_request`. O parser JSON do protobuf (`IgnoreUnknownFields(true)`) aceita isso sem erro, mas `generate_request` fica `null` (nao setado), e `GenerateRequestMapper.ToCoreDomainEntity(dto)` da null-reference na primeira linha (`dto.DateStart`) porque `dto` em si e nulo.

Reproduzido localmente com o payload real (peguei da coluna `requisicao_gerador` de um job que falhou em producao), buildando o `Ladesa.TimetableGenerator.Console` via `core/Containerfile` (`--target publicar`) e rodando com o payload capturado: confirmado o mesmo erro. Corrigido o payload (aninhando em `generate_request`) e reproduzido de novo: `isSuccessful: true`.

## Test plan
- [x] `bun --bun run typecheck` limpo
- [x] Reproduzido o bug e a correcao localmente com o binario real do gerador (`core/Containerfile`, payload real capturado de producao)
- [ ] Apos merge e deploy: `POST /api/v1/gerar-horario` completando com grade gerada, sem `GEN-0002-MAP`